### PR TITLE
lsコマンドを作る5

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -115,9 +115,9 @@ if $PROGRAM_NAME == __FILE__
   opt = OptionParser.new
 
   options = {}
-  opt.on('-a') { |boolean| options[:all] = boolean }
-  opt.on('-r') { |boolean| options[:reverse] = boolean }
-  opt.on('-l') { |boolean| options[:long] = boolean }
+  opt.on('-a') { |v| options[:all] = v }
+  opt.on('-r') { |v| options[:reverse] = v }
+  opt.on('-l') { |v| options[:long] = v }
 
   opt.parse!(ARGV)
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -4,14 +4,26 @@
 require 'etc'
 require 'fileutils'
 
-PADDING_SIZE = 7
+PADDING_SIZE = 8
 MAX_COLUMUNS = 3
 
+def calc_content_width(name_length)
+  if name_length > PADDING_SIZE
+    name_length + PADDING_SIZE - 1
+  elsif name_length == PADDING_SIZE
+    name_length + PADDING_SIZE
+  else
+    PADDING_SIZE
+  end
+end
+
 def convert_layout(file_names, line_count, max_name_length)
+  width = calc_content_width(max_name_length)
+
   lines = Array.new(line_count) { '' }
   file_names.each_slice(line_count) do |names|
     names.each_with_index do |name, index|
-      lines[index] += name.ljust(max_name_length + PADDING_SIZE)
+      lines[index] += name.ljust(width)
     end
   end
   lines.map(&:rstrip).join("\n")

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -4,12 +4,12 @@
 require 'etc'
 require 'fileutils'
 
-COLUMUN_SIZE = 8
-MAX_COLUMUNS = 3
+COLUMN_SIZE = 8
+MAX_COLUMNS = 3
 
 def calc_content_width(name_length)
-  columun_count = (name_length / COLUMUN_SIZE) + 1
-  COLUMUN_SIZE * columun_count
+  column_count = (name_length / COLUMN_SIZE) + 1
+  COLUMN_SIZE * column_count
 end
 
 def convert_layout(file_names, line_count, max_name_length)
@@ -27,7 +27,7 @@ end
 def format_contents(contents)
   return if contents.size.zero?
 
-  line_count = (contents.size / MAX_COLUMUNS.to_f).ceil
+  line_count = (contents.size / MAX_COLUMNS.to_f).ceil
   max_name_length = contents.map(&:length).max
 
   convert_layout(contents, line_count, max_name_length)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -4,17 +4,12 @@
 require 'etc'
 require 'fileutils'
 
-PADDING_SIZE = 8
+COLUMUN_SIZE = 8
 MAX_COLUMUNS = 3
 
 def calc_content_width(name_length)
-  if name_length > PADDING_SIZE
-    name_length + PADDING_SIZE - 1
-  elsif name_length == PADDING_SIZE
-    name_length + PADDING_SIZE
-  else
-    PADDING_SIZE
-  end
+  columun_count = (name_length / COLUMUN_SIZE) + 1
+  COLUMUN_SIZE * columun_count
 end
 
 def convert_layout(file_names, line_count, max_name_length)

--- a/05.ls/ls_test.rb
+++ b/05.ls/ls_test.rb
@@ -62,6 +62,24 @@ class LsTest < Minitest::Test
     assert_equal expected, list_directory_contents(TEST_DIR)
   end
 
+  def test_ls_file_length_less
+    %w[1234567 foo].each { FileUtils.touch("#{TEST_DIR}/#{_1}") }
+    expected = '1234567 foo'
+    assert_equal expected, list_directory_contents(TEST_DIR)
+  end
+
+  def test_ls_file_length_just
+    %w[12345678 foo].each { FileUtils.touch("#{TEST_DIR}/#{_1}") }
+    expected = '12345678        foo'
+    assert_equal expected, list_directory_contents(TEST_DIR)
+  end
+
+  def test_ls_file_length_more
+    %w[123456789 foo].each { FileUtils.touch("#{TEST_DIR}/#{_1}") }
+    expected = '123456789       foo'
+    assert_equal expected, list_directory_contents(TEST_DIR)
+  end
+
   def test_ls_without_opton_a
     options = {}
     assert_nil list_directory_contents(TEST_DIR, **options)

--- a/05.ls/ls_test.rb
+++ b/05.ls/ls_test.rb
@@ -108,6 +108,17 @@ class LsTest < Minitest::Test
     assert_equal ['total 0'], contents
   end
 
+  def test_ls_without_opton_a_and_r
+    %w[1 2 3].each { FileUtils.touch("#{TEST_DIR}/#{_1}") }
+    expected = <<~TEXT.chomp
+      3       1       .
+      2       ..
+    TEXT
+
+    options = { all: true, reverse: true }
+    assert_equal expected, list_directory_contents(TEST_DIR, **options)
+  end
+
   def test_filetype_char
     files =
       # Paths are on macOS

--- a/05.ls/ls_test.rb
+++ b/05.ls/ls_test.rb
@@ -126,7 +126,7 @@ class LsTest < Minitest::Test
     assert_equal ['total 0'], contents
   end
 
-  def test_ls_without_opton_a_and_r
+  def test_ls_with_opton_all_reverse
     %w[1 2 3].each { FileUtils.touch("#{TEST_DIR}/#{_1}") }
     expected = <<~TEXT.chomp
       3       1       .
@@ -135,6 +135,36 @@ class LsTest < Minitest::Test
 
     options = { all: true, reverse: true }
     assert_equal expected, list_directory_contents(TEST_DIR, **options)
+  end
+
+  def test_ls_with_opton_all_long
+    FileUtils.mkdir("#{TEST_DIR}/dummy_dir")
+    FileUtils.touch("#{TEST_DIR}/dummy_file")
+    expected_contents = `ls -al #{TEST_DIR}`.split("\n")
+
+    options = { all: true, long: true }
+    contents = list_directory_contents(TEST_DIR, **options)
+    assert_equal expected_contents, contents
+  end
+
+  def test_ls_with_opton_reverse_long
+    FileUtils.mkdir("#{TEST_DIR}/dummy_dir")
+    FileUtils.touch("#{TEST_DIR}/dummy_file")
+    expected_contents = `ls -rl #{TEST_DIR}`.split("\n")
+
+    options = { reverse: true, long: true }
+    contents = list_directory_contents(TEST_DIR, **options)
+    assert_equal expected_contents, contents
+  end
+
+  def test_ls_with_opton_all_reverse_long
+    FileUtils.mkdir("#{TEST_DIR}/dummy_dir")
+    FileUtils.touch("#{TEST_DIR}/dummy_file")
+    expected_contents = `ls -arl #{TEST_DIR}`.split("\n")
+
+    options = { all: true, reverse: true, long: true }
+    contents = list_directory_contents(TEST_DIR, **options)
+    assert_equal expected_contents, contents
   end
 
   def test_filetype_char


### PR DESCRIPTION
`-a` `-r` `-l`オプションを全て合わせたlsコマンドを作成しました。

オプションの組み合わせについては既に実現していたため、今回の対応はテストケースの追加のみです。
ただ、オプション無しのlsコマンドを作成した時に、列幅の計算方法が間違っていた事に気づいたので修正しました。

ご確認よろしくお願いします。